### PR TITLE
fix: buildSignedTxDoc should pass txRaw.fee when fee is undefined

### DIFF
--- a/networks/cosmos/src/base/tx-builder.ts
+++ b/networks/cosmos/src/base/tx-builder.ts
@@ -212,7 +212,7 @@ export abstract class BaseCosmosTxBuilder<SignDoc>
     const txRaw = await this.buildTxRaw({ messages, fee, memo, options });
 
     // buildDoc
-    const doc = await this.buildDoc({ messages, fee, memo, options }, txRaw);
+    const doc = await this.buildDoc({ messages, fee: fee ?? txRaw.fee, memo, options }, txRaw);
 
     // sign signature to the doc bytes
     const signResp = await this.ctx.signer.signDoc(doc);


### PR DESCRIPTION
When using fee: "auto" and SIGN_AMINO, `buildSignedTxDoc` should provide `this.buildDoc` with the simulated fee, as this is required for signing.

Afaik, this will only affect the amino signing as the direct signer builds the `SignDoc` differently.

Alternatively, this change can modified from `AminoTxBuilder` to accept `txRaw.fee` from the downstream. But I will leave this decision to the @hyperweb-io team