### PR TITLE
Update Cosmos signer for v53 Unordered Trxn Options

### DIFF
--- a/networks/cosmos/src/base/tx-builder.ts
+++ b/networks/cosmos/src/base/tx-builder.ts
@@ -145,6 +145,8 @@ export abstract class BaseCosmosTxBuilder<SignDoc>
       timeoutHeight: options?.timeoutHeight?.value,
       extensionOptions: options?.extensionOptions,
       nonCriticalExtensionOptions: options?.nonCriticalExtensionOptions,
+      timeoutTimestamp: options?.timeoutTimestamp?.value,
+      unordered: options?.unordered ?? false,
     });
     return {
       txBody,

--- a/networks/cosmos/src/types/signer.ts
+++ b/networks/cosmos/src/types/signer.ts
@@ -137,6 +137,11 @@ export interface TimeoutHeightOption {
   value: bigint;
 }
 
+export interface TimeoutTimestampOption {
+  type: 'absolute';
+  value: Date;
+}
+
 export type TxOptions = {
   /**
    * timeout is the block height after which this transaction will not
@@ -147,6 +152,17 @@ export type TxOptions = {
    * - type `absolute`: this.value = TxBody.timeoutHeight
    */
   timeoutHeight?: TimeoutHeightOption;
+  /**
+   * timeoutTimestamp is the time after which this transaction will not
+   * be processed by the chain; for use with unordered transactions.
+   */
+  timeoutTimestamp?: TimeoutTimestampOption;
+  /**
+   * unordered is set to true when the transaction is not ordered.
+   * Note: this requires the timeoutTimestamp to be set
+   * and the sequence to be set to 0
+   */
+  unordered?: boolean;
   /**
    * extension_options are arbitrary options that can be added by chains
    * when the default options are not sufficient. If any of these are present


### PR DESCRIPTION
This add transaction options to support `unordered` transactions as part of Cosmos SDK v53.

### **Unordered Transaction Requirements:**
Per the v53 proto files, unordered transactions have the following requirements:

_When unordered is set to true, it indicates that the transaction signer(s) intend for the transaction to be evaluated and executed in an unordered fashion. Specifically, the account’s nonce will not be checked or incremented. This allows for fire-and-forget transactions as well as concurrent execution._

_When unordered is true, the timeout_timestamp field must be set. This value defines the timestamp at which the transaction is no longer valid. Additionally, the sequence value must be 0. Any transaction with unordered=true and a non-zero sequence will be rejected._

### **Notes:**
- Only added `absolute` option to the `timeoutTimestamp` even though there's a `relative` option for `timeoutHeight` because it seems to not be fully supported.
- I'm not including any consistency checks for unordered transactions (e.g. if timeoutTimestamp is set, timeoutHeight is not) to keep the existing code clean
- This does not include updates for Injective transactions. I don't believe Injective has upgraded to support this yet so felt premature even though it's downstream and likely will in near future. Happy to add if this is desired, but I also don't have a v53 Injective chain.

### **Testing:**
I'm developing a chain that I've updated to v53, so I built out a local test case for this. There's no clean spot to put it into the repo, and the Starship tests with Osmosis also doesn't seem to support these options yet. The local test code and outputs are shown below:

**Code:**
```typescript
import { Secp256k1Auth } from '../../packages/auth/dist/secp256k1';
import { defaultSignerOptions } from '../../networks/cosmos/dist/defaults';
import { DirectSigner } from '../../networks/cosmos/dist/signers/direct';
import { AminoSigner } from '../../networks/cosmos/dist/signers/amino';
import { toEncoders } from '../../networks/cosmos/dist/utils';
import { MsgSend } from '../../libs/interchainjs/dist/cosmos/bank/v1beta1/tx';
import { HDPath } from '../../packages/types/dist';
import { Bip39, Random } from '../../packages/crypto/dist';
import { getBalance } from "../../libs/cosmos-types/dist/cosmos/bank/v1beta1/query.rpc.func";

// Test configuration for local Rebar network
const REBAR_ENDPOINTS = {
  tendermint: 'http://0.0.0.0:26657',
  api: 'http://0.0.0.0:1317',
  faucet: 'http://0.0.0.0:4500'
};

const CHAIN_ID = 'rebar-1';
const BECH32_PREFIX = 'rebar';
const DENOM = 'urebar';

// Generate a test mnemonic
function generateMnemonic(): string {
  return Bip39.encode(Random.getBytes(16)).toString();
}

// Helper function to request tokens from faucet
async function requestFromFaucet(address: string): Promise<void> {
  try {
    const response = await fetch(`${REBAR_ENDPOINTS.faucet}`, {
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',
      },
      body: JSON.stringify({
        address: address,
        coins: [`10000000${DENOM}`]
      })
    });

    if (!response.ok) {
      throw new Error(`Faucet request failed: ${response.statusText}`);
    }

    const result = await response.json();
    console.log('Faucet request successful:', result);
  } catch (error) {
    console.error('Faucet request failed:', error);
    // Continue anyway - the account might already have funds
  }
}

// Main test function
async function testTxBuilderAndSigner() {
  console.log('🧪 Starting Tx Builder and Signer Test');
  console.log('=====================================\n');

  try {
    // 1. Generate test accounts
    const mnemonic = generateMnemonic();
    console.log('🔐 Generated test mnemonic:', mnemonic);

    const hdPath1 = HDPath.cosmos(0, 0, 0).toString();
    const hdPath2 = HDPath.cosmos(0, 0, 1).toString();

    const [auth1, auth2] = Secp256k1Auth.fromMnemonic(mnemonic, [hdPath1, hdPath2]);

    // 2. Create Direct Signer (uses the new tx-builder)
    console.log('\n📝 Creating Direct Signer...');
    const directSigner = new DirectSigner(
      auth1,
      [],
      REBAR_ENDPOINTS.tendermint,
      {
        prefix: BECH32_PREFIX,
      }
    );

    // 3. Create Amino Signer (also uses tx-builder)
    console.log('📝 Creating Amino Signer...');
    const aminoSigner = new AminoSigner(
      auth2,
      [MsgSend],
      [MsgSend],
      REBAR_ENDPOINTS.tendermint,
      {
        prefix: BECH32_PREFIX,
      }
    );

    // 4. Get addresses
    const address1 = await directSigner.getAddress();
    const address2 = await aminoSigner.getAddress();

    console.log(`👤 Direct Signer Address: ${address1}`);
    console.log(`👤 Amino Signer Address: ${address2}`);

    // 5. Request funds from faucet
    console.log('\n💰 Requesting funds from faucet...');
    await requestFromFaucet(address1);
    await requestFromFaucet(address2);

    // Wait a bit for funds to be available
    await new Promise(resolve => setTimeout(resolve, 3000));

    // 6. Check balances
    console.log('\n💳 Checking initial balances...');
    const balance1 = await getBalance(REBAR_ENDPOINTS.tendermint, {
      address: address1,
      denom: DENOM
    });
    const balance2 = await getBalance(REBAR_ENDPOINTS.tendermint, {
      address: address2,
      denom: DENOM
    });

    console.log(`Balance for ${address1}: ${balance1.balance?.amount || '0'} ${DENOM}`);
    console.log(`Balance for ${address2}: ${balance2.balance?.amount || '0'} ${DENOM}`);

    // 7. Test tx-builder functionality with Direct Signer
    console.log('\n🔨 Testing Direct Signer with Tx Builder...');

    // Add MsgSend encoder
    directSigner.addEncoders(toEncoders(MsgSend));

    const directTransferAmount = '1000000'; // 1 REBAR
    const directTxArgs = {
      messages: [
        {
          typeUrl: MsgSend.typeUrl,
          value: MsgSend.fromPartial({
            fromAddress: address1,
            toAddress: address2,
            amount: [{ denom: DENOM, amount: directTransferAmount }],
          }),
        },
      ],
      fee: {
        amount: [{ denom: DENOM, amount: '5000' }],
        gas: '200000',
      },
      memo: 'Direct signer test transaction',
    };

    // Test buildTxRaw (tests tx-builder)
    console.log('  → Testing buildTxRaw...');
    const txRaw = await directSigner.txBuilder.buildTxRaw(directTxArgs);
    console.log('  ✅ buildTxRaw successful');
    console.log(`  - Body bytes length: ${txRaw.bodyBytes?.length || 0}`);
    console.log(`  - Auth info bytes length: ${txRaw.authInfoBytes?.length || 0}`);

    // Test buildSignedTxDoc (tests full tx-builder flow)
    console.log('  → Testing buildSignedTxDoc...');
    const signedDoc = await directSigner.txBuilder.buildSignedTxDoc(directTxArgs);
    console.log('  ✅ buildSignedTxDoc successful');
    console.log(`  - Signed tx has ${signedDoc.tx.signatures.length} signatures`);

    // Test unordered transactions (if supported)
    console.log('  → Testing unordered transaction option...');
    const unorderedTxArgs = {
      ...directTxArgs,
      messages: [
        {
          typeUrl: MsgSend.typeUrl,
          value: MsgSend.fromPartial({
            fromAddress: address1,
            toAddress: address2,
            amount: [{ denom: DENOM, amount: '250000' }], // Smaller amount for unordered test
          }),
        },
      ],
      memo: 'Unordered transaction test',
      options: {
        unordered: true,
        timeoutTimestamp: {
          type: 'absolute' as const,
          value: new Date(Date.now() + 300000), // 5 minutes from now
        },
        sequence: 0n,
      },
    };

    try {
      const unorderedTxRaw = await directSigner.txBuilder.buildTxRaw(unorderedTxArgs);
      console.log('  ✅ Unordered transaction build successful');
      console.log(`  - Unordered tx body bytes length: ${unorderedTxRaw.bodyBytes?.length || 0}`);

      // Actually broadcast the unordered transaction to test if it works
      console.log('  → Broadcasting unordered transaction...');
      try {
        const unorderedBroadcastResult = await directSigner.signAndBroadcast(
          unorderedTxArgs,
          { deliverTx: true }
        );
        console.log('  ✅ Unordered transaction broadcast successful');
        console.log(`  - Unordered Tx Hash: ${unorderedBroadcastResult.transactionHash}`);
        console.log(`  - Unordered Tx Height: ${unorderedBroadcastResult.height}`);
        console.log(`  - Unordered Tx Code: ${unorderedBroadcastResult.code}`);
      } catch (broadcastError: any) {
        console.log('  ❌ Unordered transaction broadcast failed:', broadcastError.message);
        console.log('  - This might be expected if the chain doesn\'t support unordered transactions');
      }
    } catch (error: any) {
      console.log('  ⚠️  Unordered transaction not supported or failed:', error.message);
    }

    // 8. Test actual transaction broadcast
    console.log('\n📡 Broadcasting Direct Signer transaction...');
    try {
      const broadcastResult = await directSigner.signAndBroadcast(
        directTxArgs,
        { deliverTx: true }
      );
      console.log('  ✅ Direct transaction broadcast successful');
      console.log(`  - Tx Hash: ${broadcastResult.transactionHash}`);
      console.log(`  - Height: ${broadcastResult.height}`);
    } catch (error: any) {
      console.log('  ❌ Direct transaction broadcast failed:', error.message);
    }

    // 9. Test Amino Signer with tx-builder
    console.log('\n🔨 Testing Amino Signer with Tx Builder...');

    // Add MsgSend encoder and converter for Amino
    aminoSigner.addEncoders(toEncoders(MsgSend));

    const aminoTransferAmount = '500000'; // 0.5 REBAR
    const aminoTxArgs = {
      messages: [
        {
          typeUrl: MsgSend.typeUrl,
          value: MsgSend.fromPartial({
            fromAddress: address2,
            toAddress: address1,
            amount: [{ denom: DENOM, amount: aminoTransferAmount }],
          }),
        },
      ],
      fee: {
        amount: [{ denom: DENOM, amount: '5000' }],
        gas: '200000',
      },
      memo: 'Amino signer test transaction',
    };

    // Test buildTxRaw for Amino
    console.log('  → Testing Amino buildTxRaw...');
    const aminoTxRaw = await aminoSigner.txBuilder.buildTxRaw(aminoTxArgs);
    console.log('  ✅ Amino buildTxRaw successful');
    console.log(`  - Body bytes length: ${aminoTxRaw.bodyBytes?.length || 0}`);

    // Test buildSignedTxDoc for Amino
    console.log('  → Testing Amino buildSignedTxDoc...');
    const aminoSignedDoc = await aminoSigner.txBuilder.buildSignedTxDoc(aminoTxArgs);
    console.log('  ✅ Amino buildSignedTxDoc successful');
    console.log(`  - Signed tx has ${aminoSignedDoc.tx.signatures.length} signatures`);

    // 10. Test actual Amino transaction broadcast
    console.log('\n📡 Broadcasting Amino Signer transaction...');
    try {
      const aminoBroadcastResult = await aminoSigner.signAndBroadcast(
        aminoTxArgs,
        { deliverTx: true }
      );
      console.log('  ✅ Amino transaction broadcast successful');
      console.log(`  - Tx Hash: ${aminoBroadcastResult.transactionHash}`);
      console.log(`  - Height: ${aminoBroadcastResult.height}`);
    } catch (error: any) {
      console.log('  ❌ Amino transaction broadcast failed:', error.message);
    }

    // 11. Final balance check
    console.log('\n💳 Checking final balances...');
    const finalBalance1 = await getBalance(REBAR_ENDPOINTS.tendermint, {
      address: address1,
      denom: DENOM
    });
    const finalBalance2 = await getBalance(REBAR_ENDPOINTS.tendermint, {
      address: address2,
      denom: DENOM
    });

    console.log(`Final balance for ${address1}: ${finalBalance1.balance?.amount || '0'} ${DENOM}`);
    console.log(`Final balance for ${address2}: ${finalBalance2.balance?.amount || '0'} ${DENOM}`);

    console.log('\n🎉 Test Complete!');
    console.log('=====================================');
    console.log('✅ Tx Builder functionality tested');
    console.log('✅ Direct Signer tested');
    console.log('✅ Amino Signer tested');
    console.log('✅ Transaction building and signing verified');
    console.log('✅ Unordered transaction support tested');

  } catch (error: any) {
    console.error('\n❌ Test failed:', error);
    console.error('Stack trace:', error.stack);
  }
}

// Run the test
if (require.main === module) {
  testTxBuilderAndSigner().catch(console.error);
}

export { testTxBuilderAndSigner };
```


**Outputs:**
```
🧪 Starting Tx Builder and Signer Test
=====================================

🔐 Generated test mnemonic: upset seek spell electric about movie answer champion program ship card citizen

📝 Creating Direct Signer...
📝 Creating Amino Signer...
👤 Direct Signer Address: rebar148fs2p7xlrmq6nxz6603fry52ucd297reuzvtl
👤 Amino Signer Address: rebar18na8nqfcl8t8n6fhgu4ff0ysn7jvkwp8fc444u

💰 Requesting funds from faucet...
Faucet request successful: {
  hash: 'F4D7FCD636FC8B300678E8508AD0D017E1203DBCAE1F28FC4B07848D68771320'
}
Faucet request successful: {
  hash: 'E6052ACD5DB6A5EF60B9A987376378BD4E3AB0046B89C87B10D8899435599786'
}

💳 Checking initial balances...
Balance for rebar148fs2p7xlrmq6nxz6603fry52ucd297reuzvtl: 10000000 urebar
Balance for rebar18na8nqfcl8t8n6fhgu4ff0ysn7jvkwp8fc444u: 10000000 urebar

🔨 Testing Direct Signer with Tx Builder...
  → Testing buildTxRaw...
  ✅ buildTxRaw successful
  - Body bytes length: 178
  - Auth info bytes length: 102
  → Testing buildSignedTxDoc...
  ✅ buildSignedTxDoc successful
  - Signed tx has 1 signatures
  → Testing unordered transaction option...
  ✅ Unordered transaction build successful
  - Unordered tx body bytes length: 188
  → Broadcasting unordered transaction...
  ✅ Unordered transaction broadcast successful
  - Unordered Tx Hash: 433385BB86577F9C12D1CECB6A8B1B31F7542100DB434560C4F84748ED930FF8
  - Unordered Tx Height: 444909
  - Unordered Tx Code: 0

📡 Broadcasting Direct Signer transaction...
  ✅ Direct transaction broadcast successful
  - Tx Hash: D187C5A47119DCE595E70E36BC705440A16BEEB8695BE7E07DEEEDEA4C9A72B1
  - Height: 444911

🔨 Testing Amino Signer with Tx Builder...
  → Testing Amino buildTxRaw...
  ✅ Amino buildTxRaw successful
  - Body bytes length: 176
  → Testing Amino buildSignedTxDoc...
  ✅ Amino buildSignedTxDoc successful
  - Signed tx has 1 signatures

📡 Broadcasting Amino Signer transaction...
  ✅ Amino transaction broadcast successful
  - Tx Hash: 102EDB39D9E5888D2793EBD2F835999180CA33F0E8E58BE051CD214ABD94AAD6
  - Height: 444914

💳 Checking final balances...
Final balance for rebar148fs2p7xlrmq6nxz6603fry52ucd297reuzvtl: 9240000 urebar
Final balance for rebar18na8nqfcl8t8n6fhgu4ff0ysn7jvkwp8fc444u: 10745000 urebar

🎉 Test Complete!
=====================================
✅ Tx Builder functionality tested
✅ Direct Signer tested
✅ Amino Signer tested
✅ Transaction building and signing verified
✅ Unordered transaction support tested
```